### PR TITLE
Switch pubsub script to using CLI flags instead of editable constants

### DIFF
--- a/google-pubsub-sync/README.md
+++ b/google-pubsub-sync/README.md
@@ -30,4 +30,4 @@ go run main.go --projectId $YOUR_PROJECT_NAME_HERE
 | Flag name  | Description                                                             | Example         |
 |------------|-------------------------------------------------------------------------|-----------------| 
 | `projectId` | The GCP Project to run this script against                              | test-project-id |
-| `env`       | The Nylas environment to run against. Valid values are: US, EU, STAGING | US              |
+| `env`       | The Nylas environment to run against. Valid values are: us, eu, staging | us               |

--- a/google-pubsub-sync/README.md
+++ b/google-pubsub-sync/README.md
@@ -15,16 +15,19 @@ gcloud config set project $YOUR_PROJECT_NAME_HERE
 gcloud auth application-default login
 ```
 
-3. Edit the `main.go` file in this directory. Set the `ENV` variable to the correct region, and the `ProjectId` constant to your GCP project name
-
-4. Fetch the dependencies.
+3. Fetch the dependencies.
 
 ```bash
 go get .
 ```
 
-5. Run the program.
+4. Run the program.
 
 ```bash
-go run main.go
+go run main.go --projectId $YOUR_PROJECT_NAME_HERE
 ```
+## Flags
+| Flag name  | Description                                                             | Example         |
+|------------|-------------------------------------------------------------------------|-----------------| 
+| `projectId` | The GCP Project to run this script against                              | test-project-id |
+| `env`       | The Nylas environment to run against. Valid values are: US, EU, STAGING | US              |

--- a/google-pubsub-sync/main.go
+++ b/google-pubsub-sync/main.go
@@ -134,11 +134,11 @@ func validateSubscriptionConfig(subscriptionConfig *pubsub.SubscriptionConfig, t
 
 func getEndpoint(env string) (string, error) {
 	switch env {
-	case "US":
+	case "us":
 		return "https://gmailrealtime.us.nylas.com", nil
-	case "EU":
+	case "eu":
 		return "https://gmailrealtime.eu.nylas.com", nil
-	case "STAGING":
+	case "staging":
 		return "https://gmailrealtime-stg.us.nylas.com", nil
 	default:
 		return "", errors.New("supplied environment that Nylas does not support")
@@ -214,7 +214,7 @@ func fetchOrCreateSubscription(ctx *context.Context, subID, projectID, env strin
 }
 
 func main() {
-	env := flag.String("env", "US", "What env the push subscription will publish to. Valid values are US, EU, STAGING. Defaults to US")
+	env := flag.String("env", "us", "What env the push subscription will publish to. Valid values are us, eu, staging. Defaults to US")
 	projectID := flag.String("projectId", "", "The GCP projectID that this script will run in")
 
 	flag.Parse()


### PR DESCRIPTION
# Code changes
- Use library `flag` to parse CLI flags to parse inputs instead of editable constants
- Update README to reflect use

Reasoning for change is to make the script easier to use by removing a step (opening the file and editing it)

# Readiness checklist
- [x] Tested by creating a pubsub topic on personal account and starting sync 

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
