### PR TITLE
Query escape service account url

### DIFF
--- a/google-pubsub-sync/main.go
+++ b/google-pubsub-sync/main.go
@@ -6,6 +6,7 @@ import (
 	"flag"
 	"fmt"
 	"log"
+    "net/url"
 	"os"
 	"strings"
 	"time"
@@ -22,7 +23,7 @@ func fetchOrCreateServiceAccount(ctx *context.Context, name, projectID string) (
 		return nil, fmt.Errorf("iam.NewService: %v", err)
 	}
 	serviceAccountUrl := fmt.Sprintf("projects/%s/serviceAccounts/%s@%s.iam.gserviceaccount.com", projectID, name, projectID)
-	account, err := service.Projects.ServiceAccounts.Get(serviceAccountUrl).Context(*ctx).Do()
+	account, err := service.Projects.ServiceAccounts.Get(url.QueryEscape(serviceAccountUrl)).Context(*ctx).Do()
 	if err != nil {
 		googleErr, ok := err.(*googleapi.Error)
 		if ok && googleErr.Code == 404 {

--- a/google-pubsub-sync/main.go
+++ b/google-pubsub-sync/main.go
@@ -6,7 +6,7 @@ import (
 	"flag"
 	"fmt"
 	"log"
-    "net/url"
+	"net/url"
 	"os"
 	"strings"
 	"time"


### PR DESCRIPTION
# Code changes
- URL encodes the service account variable due to some project IDs having some characters such as `:` that need to be encoded

# Readiness checklist
- [ ] 

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
