### PR TITLE
Remove url query escapes and update some strings

### DIFF
--- a/google-pubsub-sync/main.go
+++ b/google-pubsub-sync/main.go
@@ -49,7 +49,14 @@ func fetchOrCreateServiceAccount(ctx *context.Context, name, projectID string) (
 			googleErr, ok := err.(*googleapi.Error)
 			if ok && googleErr.Code == 409 && strings.Contains(googleErr.Message, "already exists") {
 				fmt.Printf("Service account already exists, skipping create\n")
+				account, err = service.Projects.ServiceAccounts.Get(serviceAccountUrl).Context(*ctx).Do()
+				if err != nil {
+					return nil, fmt.Errorf("failed to fetch service account: %v", err)
+				}
+				return account, nil
+
 			}
+			return nil, fmt.Errorf("Projects.ServiceAccounts.Create: %v", err)
 		}
 
 		if account == nil && account.Name != "" {

--- a/google-pubsub-sync/main.go
+++ b/google-pubsub-sync/main.go
@@ -6,7 +6,6 @@ import (
 	"flag"
 	"fmt"
 	"log"
-	"net/url"
 	"os"
 	"strings"
 	"time"
@@ -23,7 +22,7 @@ func fetchOrCreateServiceAccount(ctx *context.Context, name, projectID string) (
 		return nil, fmt.Errorf("iam.NewService: %v", err)
 	}
 	serviceAccountUrl := fmt.Sprintf("projects/%s/serviceAccounts/%s@%s.iam.gserviceaccount.com", projectID, name, projectID)
-	account, err := service.Projects.ServiceAccounts.Get(url.QueryEscape(serviceAccountUrl)).Context(*ctx).Do()
+	account, err := service.Projects.ServiceAccounts.Get(serviceAccountUrl).Context(*ctx).Do()
 	if err != nil {
 		googleErr, ok := err.(*googleapi.Error)
 		if ok && googleErr.Code == 404 {
@@ -51,8 +50,6 @@ func fetchOrCreateServiceAccount(ctx *context.Context, name, projectID string) (
 			if ok && googleErr.Code == 409 && strings.Contains(googleErr.Message, "already exists") {
 				fmt.Printf("Service account already exists, skipping create\n")
 			}
-
-			return nil, fmt.Errorf("Projects.ServiceAccounts.Create: %v", err)
 		}
 
 		if account == nil && account.Name != "" {
@@ -142,7 +139,7 @@ func getEndpoint(env string) (string, error) {
 	case "staging":
 		return "https://gmailrealtime-stg.us.nylas.com", nil
 	default:
-		return "", errors.New("supplied environment that Nylas does not support")
+		return "", errors.New("supplied environment is not supported by Nylas")
 	}
 }
 
@@ -215,7 +212,7 @@ func fetchOrCreateSubscription(ctx *context.Context, subID, projectID, env strin
 }
 
 func main() {
-	env := flag.String("env", "us", "What env the push subscription will publish to. Valid values are us, eu, staging. Defaults to US")
+	env := flag.String("env", "us", "What env the push subscription will publish to. Valid values are us, eu, staging. Defaults to us")
 	projectID := flag.String("projectId", "", "The GCP projectID that this script will run in")
 
 	flag.Parse()
@@ -261,5 +258,5 @@ func main() {
 		os.Exit(1)
 	}
 
-	fmt.Printf("Successfully setup GCP project %s for realtime google email sync", *projectID)
+	fmt.Printf("Successfully setup GCP project %s for realtime google email sync\n", *projectID)
 }


### PR DESCRIPTION
# Code changes
- We previously added a url query escape to the serviceAccountUrl. However, this should not be escaped as the library should escape for us and was causing issues finding the existing service account.
- Project IDs do not have url escapable characters: 
> Project ID requirements:
    - Must be 6 to 30 characters in length.
    - Can only contain lowercase letters, numbers, and hyphens.
    - Must start with a letter.
    - Cannot end with a hyphen.
    - Cannot be in use or previously used; this includes deleted projects.
    - Cannot contain restricted strings, such as google and ssl.

ref: https://cloud.google.com/resource-manager/docs/creating-managing-projects#before_you_begin


# Readiness checklist
- [ ] 

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
