### PR TITLE
Fix multiple environments on same topic

### DIFF
--- a/google-pubsub-sync/main.go
+++ b/google-pubsub-sync/main.go
@@ -258,7 +258,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	_, err = fetchOrCreateSubscription(&ctx, "push-nylas-gmail-realtime-sub", *projectID, *env, topic, serviceAccount)
+	_, err = fetchOrCreateSubscription(&ctx, "push-nylas-gmail-realtime-sub-"+*env, *projectID, *env, topic, serviceAccount)
 
 	if err != nil {
 		fmt.Printf("Failed to create subscription with error %v, exiting\n", err)


### PR DESCRIPTION
# Description
We ran into an issue creating multiple subscriptions for multiple environments. Now with separate ids per environments, we can create and validate subscriptions for multiple environments. 

# Code changes
- Appends the environment to the subscription ID so that we can re-use the same topic for multiple subscriptions

# Readiness checklist
- [ ] 

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
